### PR TITLE
krita.desktop - added StartupWMClass

### DIFF
--- a/krita/org.kde.krita.desktop
+++ b/krita/org.kde.krita.desktop
@@ -149,3 +149,4 @@ X-KDE-NativeMimeType=application/x-krita
 X-KDE-ExtraNativeMimeTypes=
 StartupNotify=true
 X-Krita-Version=28
+StartupWMClass=krita


### PR DESCRIPTION
Without this patch, when the icon is added to the launcher, in Ubuntu (gnome), and it is clicked, then a new icon is added dynamically to the pane, with the dot on its left showing the new icon as an active application. With this patch, this is fixed, and now when I click on the Krita icon in the launcher, I just get a dot on its left, showing it as an active application.

DO NOT ISSUE PULL REQUESTS ON GITHUB

Github is only a mirror. Our real development happens on
the KDE infrastructure. Post diffs and review requests
against Krita here:

https://phabricator.kde.org
